### PR TITLE
Add nli head

### DIFF
--- a/drbert/heads.py
+++ b/drbert/heads.py
@@ -1,11 +1,12 @@
 import torch
 from torch import nn
 from torch.nn import CrossEntropyLoss
+from torch.nn import MSELoss
 
 
 class SequenceLabellingHead(torch.nn.Module):
     """A head which can be placed at the output of a language model (such as BERT) to perform
-    sequence labelling tasks.
+    sequence labelling tasks (e.g. de-identification or NER).
 
     Args:
         config (BertConfig): `BertConfig` class instance with a configuration to build a new model.
@@ -29,9 +30,10 @@ class SequenceLabellingHead(torch.nn.Module):
         >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
         >>> config = AutoConfig.from_pretrained('bert-base-uncased')
         >>> bert = AutoModel.from_pretrained('bert-base-uncased')
-        >>> head = SequenceLabellingHead()
-        >>> input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
-        >>> labels = torch.tensor([1] * input_ids.size(1)).unsqueeze(0)  # Batch size 1
+        >>> head = SequenceLabellingHead(config)
+        >>> input_ids = tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)
+        >>> input_ids = torch.tensor(input_ids).unsqueeze(0)  # Batch size 1
+        >>> labels = torch.tensor([1] * input_ids.size(1)).unsqueeze(0)
         >>> outputs = head(bert, input_ids, labels=labels)
         >>> loss, scores = outputs[:2]
     """
@@ -46,6 +48,7 @@ class SequenceLabellingHead(torch.nn.Module):
     def forward(self, bert, input_ids, attention_mask=None, token_type_ids=None, position_ids=None,
                 head_mask=None, labels=None):
         outputs = bert(input_ids, attention_mask, token_type_ids, position_ids, head_mask)
+
         sequence_output = outputs[0]
 
         sequence_output = self.dropout(sequence_output)
@@ -65,6 +68,70 @@ class SequenceLabellingHead(torch.nn.Module):
             outputs = (loss,) + outputs
 
         return outputs  # (loss), scores, (hidden_states), (attentions)
+
+
+class SequenceClassificationHead(torch.nn.Module):
+    """A head which can be placed at the output of a language model (such as BERT) to perform
+    sequence classification tasks (e.g. natural language inference or relation extraction).
+
+    Args:
+        config (BertConfig): `BertConfig` class instance with a configuration to build a new model.
+
+    Outputs: `Tuple` comprising various elements depending on the configuration (config) and inputs:
+        - loss: (optional, returned when `labels` is provided) `torch.FloatTensor` of shape `(1,)`:
+            Classification loss.
+        - scores: `torch.FloatTensor` of shape `(batch_size, sequence_length, config.num_labels)`
+            Classification scores (before SoftMax).
+        - hidden_states: (`optional`, returned when `config.output_hidden_states=True`)
+            list of `torch.FloatTensor` (one for the output of each layer + the output of the
+            embeddings) of shape `(batch_size, sequence_length, hidden_size)`: Hidden-states of the
+            model at the output of each layer plus the initial embedding outputs.
+        - attentions: (`optional`, returned when `config.output_attentions=True`)
+            list of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads,
+            sequence_length, sequence_length)`: Attentions weights after the attention softmax, used
+            to compute the weighted average in the self-attention heads.
+
+    Examples:
+        >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
+        >>> config = AutoConfig.from_pretrained('bert-base-uncased')
+        >>> bert = AutoModel.from_pretrained('bert-base-uncased')
+        >>> head = SequenceClassificationHead(config)
+        >>> input_ids = tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)
+        >>> input_ids = torch.tensor(input_ids).unsqueeze(0)  # Batch size 1
+        >>> labels = torch.tensor([1]).unsqueeze(0)
+        >>> outputs = head(bert, input_ids, labels=labels)
+        >>> loss, logits = outputs[:2]
+    """
+    def __init__(self, config):
+        super(SequenceClassificationHead, self).__init__()
+        self.num_labels = config.num_labels
+
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+        self.classifier = nn.Linear(config.hidden_size, config.num_labels)
+
+    def forward(self, bert, input_ids, attention_mask=None, token_type_ids=None, position_ids=None,
+                head_mask=None, labels=None):
+
+        outputs = bert(input_ids, attention_mask, token_type_ids, position_ids, head_mask)
+
+        pooled_output = outputs[1]
+
+        pooled_output = self.dropout(pooled_output)
+        logits = self.classifier(pooled_output)
+
+        outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
+
+        if labels is not None:
+            if self.num_labels == 1:
+                #  We are doing regression
+                loss_fct = MSELoss()
+                loss = loss_fct(logits.view(-1), labels.view(-1))
+            else:
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
+            outputs = (loss,) + outputs
+
+        return outputs  # (loss), logits, (hidden_states), (attentions)
 
 
 class DocumentClassificationHead(torch.nn.Module):
@@ -92,46 +159,53 @@ class DocumentClassificationHead(torch.nn.Module):
         >>> tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
         >>> config = AutoConfig.from_pretrained('bert-base-uncased')
         >>> bert = AutoModel.from_pretrained('bert-base-uncased')
-        >>> head = DocumentClassificationHead()
-        >>> input_ids = torch.tensor(tokenizer.encode("Hello, my dog is cute")).unsqueeze(0)  # Batch size 1
+        >>> head = DocumentClassificationHead(config)
+        >>> input_ids = tokenizer.encode("Hello, my dog is cute", add_special_tokens=True)
+        >>> input_ids = torch.tensor(input_ids).unsqueeze(0)  # Batch size 1
         >>> labels = torch.ones(0, 4, (16, 4))  # E.g. 16 diseases, with 4 classes each.
         >>> outputs = head(bert, input_ids, labels=labels)
-        >>> loss, scores = outputs[:2]
+        >>> loss, logits = outputs[:2]
     """
     def __init__(self, config):
         super(DocumentClassificationHead, self).__init__()
         # TODO (John): This will eventually be decoupled from the cohort task
-        # For non-multi label datasets, num_classes will be 1
+        # For non-multi label datasets, num_classes[0] will be 1
         self.num_labels = config.num_cohort_labels
 
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
-        self.classifier = nn.Sequential(
-            nn.Linear(config.hidden_size, config.cohort_ffnn_size),
-            nn.ReLU(),
-            nn.Dropout(config.hidden_dropout_prob),
-            nn.Linear(config.cohort_ffnn_size, config.cohort_ffnn_size // 2),
-            nn.ReLU(),
-            nn.Dropout(config.hidden_dropout_prob),
-            nn.Linear(config.cohort_ffnn_size // 2, self.num_labels[0] * self.num_labels[1])
+        self.lstm = nn.LSTM(
+            input_size=config.hidden_size,
+            hidden_size=config.cohort_ffnn_size,
+            num_layers=2,
+            batch_first=True,
+            dropout=config.hidden_dropout_prob,
+            bidirectional=True,
         )
+
+        self.classifier = nn.Linear(config.cohort_ffnn_size * 2, self.num_labels[0] * self.num_labels[1])
 
     def forward(self, bert, input_ids, attention_mask=None, token_type_ids=None, position_ids=None,
                 head_mask=None, labels=None):
         outputs = bert(input_ids, attention_mask, token_type_ids, position_ids, head_mask)
-        cls_output = outputs[1]
 
-        # Pool outputs
-        cls_output = torch.sum(cls_output, dim=0)
-        cls_output = self.dropout(cls_output)
+        pooled_outputs = outputs[1]
+        pooled_outputs = self.dropout(pooled_outputs)
 
-        logits = self.classifier(cls_output)
+        reccurent_outputs, _ = self.lstm(pooled_outputs.unsqueeze(0))  # batch dim of 1
+        reccurent_outputs = reccurent_outputs[:, -1, :].squeeze(0)  # hidden state of final timestep
+
+        logits = self.classifier(reccurent_outputs)
         logits = logits.view(self.num_labels)
 
         outputs = (logits,) + outputs[2:]  # add hidden states and attention if they are here
-        if labels is not None:
-            loss_fct = CrossEntropyLoss()
 
-            loss = loss_fct(logits.view(*self.num_labels), labels.view(-1))
+        if labels is not None:
+            if self.num_labels[0] == 1:
+                loss_fct = MSELoss()
+                loss = loss_fct(logits.view(-1), labels.view(-1))
+            else:
+                loss_fct = CrossEntropyLoss()
+                loss = loss_fct(logits.view(self.num_labels), labels.view(-1))
             outputs = (loss,) + outputs
 
         return outputs  # (loss), scores, (hidden_states), (attentions)

--- a/drbert/tests/conftest.py
+++ b/drbert/tests/conftest.py
@@ -4,6 +4,7 @@ from transformers import BertModel
 from transformers import BertTokenizer
 
 from ..heads import DocumentClassificationHead
+from ..heads import SequenceClassificationHead
 from ..heads import SequenceLabellingHead
 
 
@@ -43,6 +44,19 @@ def sequence_labelling_head(bert_config):
     bert_config.__dict__['num_deid_labels'] = num_labels
 
     head = SequenceLabellingHead(bert_config)
+
+    return batch_size, sequence_length, num_labels, head
+
+
+@pytest.fixture
+def sequence_classification_head(bert_config):
+    """Initialized sequence classification head.
+    """
+    batch_size, sequence_length, num_labels = 1, 8, 2
+    # TODO (John): This will change when we decouple the model from these tasks.
+    bert_config.__dict__['num_labels'] = num_labels
+
+    head = SequenceClassificationHead(bert_config)
 
     return batch_size, sequence_length, num_labels, head
 

--- a/drbert/tests/test_heads.py
+++ b/drbert/tests/test_heads.py
@@ -1,7 +1,6 @@
 import torch
 from torch import nn
 from transformers import BertModel
-from random import randint
 
 VOCAB = 30000  # BERT has a vocab of ~30K
 
@@ -102,14 +101,112 @@ class TestSequenceLabellingHead(object):
 
         assert len(outputs) == 2
         assert outputs[0].size() == torch.Size([])  # Loss is a single element tensor
-        assert outputs[1].size() == (batch_size, sequence_length, num_labels)
+        assert outputs[1].size() == (batch_size, num_labels)
+
+
+class TestSequenceClassificationHead(object):
+    """Collects all unit tests for `drbert.heads.SequenceClassificationHead`.
+    """
+    def test_attributes_after_initialization(self, bert_config, sequence_classification_head):
+        _, sequence_length, num_labels, head = sequence_classification_head
+
+        assert head.num_labels == num_labels
+        assert isinstance(head.dropout, (nn.Module, nn.Dropout))
+        assert isinstance(head.classifier, (nn.Module, nn.Linear))
+
+    def test_forward_pass_input_ids_only(self, bert, bert_config, sequence_classification_head):
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.LongTensor(batch_size, sequence_length).random_(0, VOCAB)
+
+        outputs = head(bert, input_ids)
+
+        assert len(outputs) == 1
+        assert outputs[0].size() == (batch_size, num_labels)
+
+    def test_forward_pass_with_attn_masks(self, bert, sequence_classification_head):
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.randint(VOCAB, (batch_size, sequence_length))
+        attention_mask = torch.randint(2, (batch_size, sequence_length))
+
+        outputs = head(bert, input_ids, attention_mask=attention_mask)
+
+        assert len(outputs) == 1
+        assert outputs[0].size() == (batch_size, num_labels)
+
+    def test_forward_pass_with_token_type_ids(self, bert, sequence_classification_head):
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.randint(VOCAB, (batch_size, sequence_length))
+        token_type_ids = torch.ones_like(input_ids)
+
+        outputs = head(bert, input_ids, token_type_ids=token_type_ids)
+
+        assert len(outputs) == 1
+        assert outputs[0].size() == (batch_size, num_labels)
+
+    def test_forward_pass_with_position_ids(self, bert, sequence_classification_head):
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.randint(VOCAB, (batch_size, sequence_length))
+        position_ids = torch.arange(sequence_length, dtype=torch.long)
+        position_ids = position_ids.unsqueeze(0).expand_as(input_ids)
+
+        outputs = head(bert, input_ids, position_ids=position_ids)
+
+        assert len(outputs) == 1
+        assert outputs[0].size() == (batch_size, num_labels)
+
+    def test_forward_pass_with_head_mask(self, bert_config, sequence_classification_head):
+        # We need all hidden states to confirm the head masking worked as expected
+        bert_config.output_attentions = True
+        bert = BertModel(bert_config)
+
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.randint(VOCAB, (batch_size, sequence_length))
+        head_mask = torch.ones(bert_config.num_attention_heads)
+        # Turn on one head at random
+        masked_head = torch.randint(0, head_mask.size(-1), ())
+        head_mask[masked_head] = 0
+
+        outputs = head(bert, input_ids, head_mask=head_mask)
+
+        assert len(outputs) == 2
+        assert outputs[0].size() == (batch_size, num_labels)
+
+        # Asserts that attention weights are of the expected size, and that one of the attention
+        # heads was masked.
+        output_shape = \
+            (batch_size, bert_config.num_attention_heads, sequence_length, sequence_length)
+        for attention_weights in outputs[1]:
+            assert attention_weights.size() == output_shape
+            for head, weights in enumerate(attention_weights):
+                if head == masked_head:
+                    print(weights, torch.zeros_like(weights))
+                    assert torch.equal(weights, torch.zeros_like(weights))
+                else:
+                    assert not torch.equal(weights, torch.zeros_like(weights))
+
+    def test_forward_pass_with_labels(self, bert, sequence_classification_head):
+        batch_size, sequence_length, num_labels, head = sequence_classification_head
+
+        input_ids = torch.randint(VOCAB, (batch_size, sequence_length))
+        labels = torch.randint(num_labels, (batch_size,))
+
+        outputs = head(bert, input_ids, labels=labels)
+
+        assert len(outputs) == 2
+        assert outputs[0].size() == torch.Size([])  # Loss is a single element tensor
+        assert outputs[1].size() == (batch_size, num_labels)
 
 
 class TestDocumentClassificationHead(object):
     """Collects all unit tests for `drbert.heads.DocumentClassificationHead`.
     """
-    def test_attributes_after_initialization(self, bert_config, sequence_labelling_head):
-        _, sequence_length, num_labels, head = sequence_labelling_head
+    def test_attributes_after_initialization(self, bert_config, document_classification_head):
+        _, sequence_length, num_labels, head = document_classification_head
 
         assert head.num_labels == num_labels
         assert isinstance(head.dropout, (nn.Module, nn.Dropout))

--- a/drbert/tests/test_heads.py
+++ b/drbert/tests/test_heads.py
@@ -101,7 +101,7 @@ class TestSequenceLabellingHead(object):
 
         assert len(outputs) == 2
         assert outputs[0].size() == torch.Size([])  # Loss is a single element tensor
-        assert outputs[1].size() == (batch_size, num_labels)
+        assert outputs[1].size() == (batch_size, sequence_length, num_labels)
 
 
 class TestSequenceClassificationHead(object):


### PR DESCRIPTION
# Overview

This PR adds a head for sequence labelling tasks (e.g. NLI or RE) in `drbert.heads.SequenceClassificationHead`. The head is a near-direct copy from [Transformers](https://github.com/huggingface/transformers/blob/be916cb3fb4579e278ceeaec11a6524662797d7f/transformers/modeling_bert.py#L849).